### PR TITLE
Fix code scanning alert no. 16: Multiplication result converted to larger type

### DIFF
--- a/bnetd/bnetd-0.4.27.2/src/bniutils/tga.c
+++ b/bnetd/bnetd-0.4.27.2/src/bniutils/tga.c
@@ -54,10 +54,10 @@ static int rotate_updown(t_tgaimg *img) {
 	if (img->data == NULL) return -1;
 	pixelsize = getpixelsize(img);
 	if (pixelsize == 0) return -1;
-	ndata = malloc(img->width*img->height*pixelsize);
+	ndata = malloc((size_t)img->width * img->height * pixelsize);
 	for (y = 0; y < img->height; y++) {
-		memcpy(ndata + (y*img->width*pixelsize),
-		       img->data + ((img->width*img->height*pixelsize)-((y+1)*img->width*pixelsize)),
+		memcpy(ndata + ((size_t)y * img->width * pixelsize),
+		       img->data + (((size_t)img->width * img->height * pixelsize) - ((size_t)(y + 1) * img->width * pixelsize)),
 		       img->width*pixelsize);
 	}
 	free(img->data);
@@ -74,10 +74,10 @@ static int rotate_leftright(t_tgaimg *img) {
         if (img->data == NULL) return -1;
         pixelsize = getpixelsize(img);
         if (pixelsize == 0) return -1;
-        ndata = malloc(img->width*img->height*pixelsize);
+        ndata = malloc((size_t)img->width * img->height * pixelsize);
 	datap = img->data;
         for (y = 0; y < img->height; y++) {
-		unsigned char *linep = (ndata + (((y+1)*img->width*pixelsize)-pixelsize));
+		unsigned char *linep = (ndata + (((size_t)(y + 1) * img->width * pixelsize) - pixelsize));
 		for (x = 0; x < img->width; x++) {
 			memcpy(linep,datap,pixelsize);
 			linep -= pixelsize;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/bnetd/security/code-scanning/16](https://github.com/cooljeanius/bnetd/security/code-scanning/16)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type before the result is used. This can be achieved by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the larger type, preventing overflow.

Specifically, we need to modify the multiplication operations in the `rotate_updown` and `rotate_leftright` functions to cast one of the operands to `size_t`. This change should be made in the following lines:
- Line 57: `ndata = malloc(img->width * img->height * pixelsize);`
- Line 59: `memcpy(ndata + (y * img->width * pixelsize), ...`
- Line 60: `img->data + ((img->width * img->height * pixelsize) - ((y + 1) * img->width * pixelsize)), ...`
- Line 77: `ndata = malloc(img->width * img->height * pixelsize);`
- Line 80: `unsigned char *linep = (ndata + (((y + 1) * img->width * pixelsize) - pixelsize));`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
