### PR TITLE
Fix code scanning alert no. 16: Multiplication result converted to larger type

### DIFF
--- a/bnetd/bnetd-0.4.27.2/src/bniutils/tga.c
+++ b/bnetd/bnetd-0.4.27.2/src/bniutils/tga.c
@@ -58,7 +58,7 @@ static int rotate_updown(t_tgaimg *img) {
 	for (y = 0; y < img->height; y++) {
 		memcpy(ndata + ((size_t)y * img->width * pixelsize),
 		       img->data + (((size_t)img->width * img->height * pixelsize) - ((size_t)(y + 1) * img->width * pixelsize)),
-		       img->width*pixelsize);
+		       (size_t)img->width * pixelsize);
 	}
 	free(img->data);
 	img->data = ndata;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/bnetd/security/code-scanning/16](https://github.com/cooljeanius/bnetd/security/code-scanning/16)

To fix the problem, we need to ensure that the multiplication is performed using the larger type (`size_t`) to prevent overflow. This can be achieved by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the larger type, and any potential overflow will be avoided.

Specifically, we need to modify the multiplication on line 61 to cast `img->width` to `size_t` before multiplying it by `pixelsize`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
