### PR TITLE
Fix code scanning alert no. 10: Multiplication result converted to larger type

### DIFF
--- a/bnetd/bnetd-0.4.27.2/src/bniutils/tga.c
+++ b/bnetd/bnetd-0.4.27.2/src/bniutils/tga.c
@@ -256,8 +256,8 @@ extern int write_tga(FILE *f, t_tgaimg *img) {
 
 		pixelsize = getpixelsize(img);
 		if (pixelsize == 0) return -1;
-		if (fwrite(img->data,pixelsize,img->width*img->height,f)<img->width*img->height) {
-			fprintf(stderr,"write_tga: could not write %d pixels (fwrite: %s)\n",img->width*img->height,strerror(errno));
+		if (fwrite(img->data, pixelsize, (size_t)img->width * img->height, f) < (size_t)img->width * img->height) {
+			fprintf(stderr,"write_tga: could not write %zu pixels (fwrite: %s)\n", (size_t)img->width * img->height, strerror(errno));
 			file_wpop();
 			return -1;
 		}


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/bnetd/security/code-scanning/10](https://github.com/cooljeanius/bnetd/security/code-scanning/10)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to avoid overflow. This can be done by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done using the larger type, and the result will not overflow.

Specifically, we will cast `img->width` to `size_t` before multiplying it by `img->height` on line 259. This change will ensure that the multiplication is performed using `size_t`, which is large enough to hold the result without overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
