### PR TITLE
Fix code scanning alert no. 8: Multiplication result converted to larger type

### DIFF
--- a/bnetd/bnetd-0.4.27.2/src/bniutils/tga.c
+++ b/bnetd/bnetd-0.4.27.2/src/bniutils/tga.c
@@ -380,7 +380,7 @@ static int RLE_compress(FILE *f, t_tgaimg const *img) {
 	if (pixelsize == 0) return -1;
 
 	datap = img->data;
-	pktdata = malloc(img->width*img->height*pixelsize);
+	pktdata = malloc((size_t)img->width * (size_t)img->height * (size_t)pixelsize);
 	pktlen = 0;
 
 	for (i=0; i<img->width*img->height; ) {


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/bnetd/security/code-scanning/8](https://github.com/cooljeanius/bnetd/security/code-scanning/8)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. Specifically, we should cast the operands to `size_t` before performing the multiplication. This will ensure that the multiplication is done using the larger type, and the result will be correctly passed to `malloc`.

We will modify the line where the multiplication occurs (line 383) to cast the operands to `size_t` before multiplying them. This change will prevent overflow and ensure that the correct amount of memory is allocated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
