### PR TITLE
Fix code scanning alert no. 7: Multiplication result converted to larger type

### DIFF
--- a/bnetd/bnetd-0.4.27.2/src/bniutils/bniextract.c
+++ b/bnetd/bnetd-0.4.27.2/src/bniutils/bniextract.c
@@ -89,7 +89,7 @@ static t_tgaimg * area2img(t_tgaimg *src, int x, int y, int width, int height, t
 	destp = dst->data;
 	for (i = 0; i < height; i++) {
 		datap += x*pixelsize;
-		memcpy(destp,datap,width*pixelsize);
+		memcpy(destp,datap,(size_t)width*pixelsize);
 		destp += width*pixelsize;
 		datap += (src->width-x)*pixelsize;
 	}


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/bnetd/security/code-scanning/7](https://github.com/cooljeanius/bnetd/security/code-scanning/7)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to avoid overflow. This can be done by casting one of the operands to `size_t` before performing the multiplication. Specifically, we should cast `width` to `size_t` in the multiplication `width * pixelsize` on line 92. This will ensure that the multiplication is done using the larger type, preventing overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
