### PR TITLE
Fix code scanning alert no. 6: Multiplication result converted to larger type

### DIFF
--- a/bnetd/bnetd-0.4.27.2/src/bniutils/bniextract.c
+++ b/bnetd/bnetd-0.4.27.2/src/bniutils/bniextract.c
@@ -82,7 +82,7 @@ static t_tgaimg * area2img(t_tgaimg *src, int x, int y, int width, int height, t
 	if (pixelsize == 0) return NULL;
 	
 	dst = new_tgaimg(width,height,src->bpp,type);
-	dst->data = malloc(width*height*pixelsize);
+	dst->data = malloc((size_t)width * height * pixelsize);
 	
 	datap = src->data;
 	datap += y*src->width*pixelsize;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/bnetd/security/code-scanning/6](https://github.com/cooljeanius/bnetd/security/code-scanning/6)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to avoid overflow. This can be achieved by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the `size_t` type, which is typically larger than `int` and can hold larger values.

The specific change involves casting `width` to `size_t` before the multiplication on line 85. This ensures that the entire multiplication is performed in the `size_t` type, preventing overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
