### PR TITLE
Fix code scanning alert no. 5: Multiplication result converted to larger type

### DIFF
--- a/bnetd/bnetd-0.4.27.2/src/bniutils/bnibuild.c
+++ b/bnetd/bnetd-0.4.27.2/src/bniutils/bnibuild.c
@@ -155,8 +155,8 @@ static int img2area(t_tgaimg *dst, t_tgaimg *src, int x, int y) {
 	ddp = dst->data + (y * dst->width * pixelsize);
 	for (i = 0; i < src->height; i++) {
 		ddp += x*pixelsize;
-		memcpy(ddp,sdp,src->width*pixelsize);
-		sdp += src->width*pixelsize;
+		memcpy(ddp,sdp,(size_t)src->width*pixelsize);
+		sdp += (size_t)src->width*pixelsize;
 		ddp += (dst->width-x)*pixelsize;
 	}
 	return 0;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/bnetd/security/code-scanning/5](https://github.com/cooljeanius/bnetd/security/code-scanning/5)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be achieved by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the larger type, and the result will be correctly represented.

Specifically, we will cast `pixelsize` to `size_t` before multiplying it with `src->width`. This change will be made on line 158 of the file `bnetd/bnetd-0.4.27.2/src/bniutils/bnibuild.c`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
