### PR TITLE
Fix code scanning alert no. 4: Multiplication result converted to larger type

### DIFF
--- a/bnetd/bnetd-0.4.27.2/src/bniutils/bnibuild.c
+++ b/bnetd/bnetd-0.4.27.2/src/bniutils/bnibuild.c
@@ -278,7 +278,7 @@ extern int main(int argc, char * argv[])
 		img->height += bni.icons->icon[i].y;
 	}
 	fprintf(stderr,"Info: Creating TGA with %ux%ux%ubpp.\n",img->width,img->height,img->bpp);
-	img->data = malloc(img->width*img->height*getpixelsize(img));
+	img->data = malloc((size_t)img->width * (size_t)img->height * (size_t)getpixelsize(img));
 	yline = 0;
 	for (i = 0; i < bni.numicons; i++) {
 		t_tgaimg *icon;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/bnetd/security/code-scanning/4](https://github.com/cooljeanius/bnetd/security/code-scanning/4)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. Specifically, we should cast the operands to `size_t` before performing the multiplication. This will ensure that the multiplication is done in the larger type, avoiding overflow.

- **General Fix:** Cast the operands to `size_t` before performing the multiplication.
- **Detailed Fix:** Modify the line where the multiplication occurs to cast `img->width`, `img->height`, and `getpixelsize(img)` to `size_t` before multiplying them.
- **Specific Changes:** Update line 281 in the file `bnetd/bnetd-0.4.27.2/src/bniutils/bnibuild.c` to include the necessary casts.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
